### PR TITLE
Add custom entrypoint to support direct execution of module.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,8 @@ RUN apt-get update && apt-get install -y \
 && rm -rf /var/lib/apt/lists/*
 COPY ./imagick/policy.xml /etc/ImageMagick-6/policy.xml
 WORKDIR /code
+
+COPY pastvu-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["pastvu-entrypoint.sh"]
+
+CMD [ "node" ]

--- a/pastvu-entrypoint.sh
+++ b/pastvu-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# 'run MODULE [options]' special command to run script directly with node, so that system signals are relayed to the process.
+if [ "$1" = 'run' -a -f "./${2}.js" ]; then
+  MODULE=$2
+  shift 2
+  exec node ./bin/run.js --script "./${MODULE}.js" "$@"
+fi
+
+# Fallback to node image entrypoint.
+exec docker-entrypoint.sh "$@"


### PR DESCRIPTION
We use npm to start services, but it does not relay system signals to the process correctly in docker environment (see [this](https://github.com/goldbergyoni/nodebestpractices/blob/master/sections/docker/bootstrap-using-node.md) for technical details). This patch introduces entrypoint that process custom run command syntax which runs module using node directly:
```
  run MODULE [options]

  MODULE    Module to run (e.g. app, downloader, uploader, etc.)
  options   Any valid node params that needs to be added (e.g. --max-old-space-size=4096).
```
If command is not mathing syntax, it will be passed to `docker-entrypoint.sh` provided by node image (so that any `npm` command will work as usual).